### PR TITLE
Fix first time contributor detection

### DIFF
--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -98,11 +98,16 @@ func (c *Congratulator) Do(ctx context.Context, repo *maintner.GitHubRepo) error
 			c.knownContributors[username] = true
 			continue
 		}
+		hasNewContributorLabel := false
 		for _, label := range ghIssue.Labels {
 			if label.Name == "new-contributor" {
-				c.knownContributors[username] = true
-				continue
+				hasNewContributorLabel = true
+				break
 			}
+		}
+		if hasNewContributorLabel {
+			c.knownContributors[username] = true
+			continue
 		}
 		cdata := &CongratsData{
 			Username: ghIssue.User.Login,


### PR DESCRIPTION
Before the `continue` didn't continue on the outer `for` loop, which should be (one/the) cause for multiple postings of the new contributor postings